### PR TITLE
Warning cleanup

### DIFF
--- a/PDQ_MinLib/PDQ_GFX.h
+++ b/PDQ_MinLib/PDQ_GFX.h
@@ -839,7 +839,7 @@ void PDQ_GFX<HW>::drawChar(coord_t x, coord_t y, unsigned char c, color_t color,
 
 // Draw a character with GFX font
 template<class HW>
-void PDQ_GFX<HW>::drawCharGFX(coord_t x, coord_t y, unsigned char c, color_t color, color_t bg, uint8_t size)
+void PDQ_GFX<HW>::drawCharGFX(coord_t x, coord_t y, unsigned char c, color_t color, color_t /*bg*/, uint8_t size)
 {
   // Character is assumed previously filtered by write() to eliminate
   // newlines, returns, non-printable characters, etc.	Calling drawChar()

--- a/encoder.cpp
+++ b/encoder.cpp
@@ -83,7 +83,7 @@ void enc_setup(void)
   TCCR1A = 0;//"normal" mode
   TCCR1B = 3;//clock divider of 64
   TCNT1  = 0;//start counting at 0
-  OCR1A  = F_CPU * CALLBACK_PERIOD_MS / 1000 / 64;//set target number
+  OCR1A  = F_CPU * (unsigned long)CALLBACK_PERIOD_MS / 1000 / 64;//set target number
   TIMSK1 |= (1 << OCIE1A);//enable interrupt
 }
 

--- a/keyer.cpp
+++ b/keyer.cpp
@@ -29,7 +29,7 @@
  */
 
  //CW ADC Range
-static const unsigned int cwAdcSTFrom = 0;
+//static const unsigned int cwAdcSTFrom = 0;
 static const unsigned int cwAdcSTTo = 50;
 static const unsigned int cwAdcBothFrom = cwAdcSTTo + 1;
 static const unsigned int cwAdcBothTo = 300;
@@ -79,7 +79,7 @@ uint8_t keyerControl = 0;
 char update_PaddleLatch(bool isUpdateKeyState) {
   unsigned char tmpKeyerControl = 0;
   
-  int paddle = analogRead(ANALOG_KEYER);
+  unsigned int paddle = analogRead(ANALOG_KEYER);
 
   //use the PTT as the key for tune up, quick QSOs
   if (digitalRead(PTT) == 0)
@@ -93,7 +93,7 @@ char update_PaddleLatch(bool isUpdateKeyState) {
   else{
     if (KeyerMode_e::KEYER_STRAIGHT != globalSettings.keyerMode)
       tmpKeyerControl = 0 ;
-    else if (paddle >= cwAdcSTFrom && paddle <= cwAdcSTTo)
+    else if (paddle <= cwAdcSTTo)
       tmpKeyerControl = DIT_L ;
      else
        tmpKeyerControl = 0 ;

--- a/morse.cpp
+++ b/morse.cpp
@@ -66,7 +66,7 @@ static void morseLetter(char c, uint16_t dit_duration_ms){
     return;
   }
 
-  for (int i = 0; i < sizeof(morse_table)/ sizeof(struct Morse); i++){
+  for (unsigned int i = 0; i < sizeof(morse_table)/ sizeof(struct Morse); i++){
     struct Morse m;
     memcpy_P(&m, morse_table + i, sizeof(struct Morse));
 

--- a/nano_gui.cpp
+++ b/nano_gui.cpp
@@ -162,7 +162,7 @@ PDQ_ILI9341 tft;
 #include "nano_font.h"
 
 
-bool xpt2046_Init(){
+void xpt2046_Init(){
   pinMode(CS_PIN, OUTPUT);
   digitalWrite(CS_PIN, HIGH);
 }
@@ -246,7 +246,8 @@ void setupTouch(){
   int x1, y1, x2, y2, x3, y3, x4, y4;
   
   displayClear(DISPLAY_BLACK);
-  displayText("Click on the cross", 20,100, 200, 50, DISPLAY_WHITE, DISPLAY_BLACK, DISPLAY_BLACK);
+  strncpy_P(b,(const char*)F("Click on the cross"),sizeof(b));
+  displayText(b, 20,100, 200, 50, DISPLAY_WHITE, DISPLAY_BLACK, DISPLAY_BLACK);
 
   // TOP-LEFT
   displayHline(10,20,20,DISPLAY_WHITE);

--- a/setup.cpp
+++ b/setup.cpp
@@ -87,7 +87,7 @@ struct SettingScreen_t {
 
 void runSetting(const SettingScreen_t* const p_screen)
 {
-  SettingScreen_t screen = {0};
+  SettingScreen_t screen = {nullptr,nullptr,0,0,nullptr,nullptr,nullptr,nullptr};
   memcpy_P(&screen,p_screen,sizeof(screen));
   displayDialog(screen.Title,
                 screen.AdditionalText);
@@ -235,7 +235,7 @@ void ssCwSpeedValidate(const long int candidate_value_in, long int* validated_va
 {
   *validated_value_out = LIMIT(candidate_value_in,1,100);
 }
-void ssCwSpeedChange(const long int new_value, char* buff_out, const size_t buff_out_size)
+void ssCwSpeedChange(const long int new_value, char* buff_out, const size_t /*buff_out_size*/)
 {
   ltoa(new_value, buff_out, 10);
 }
@@ -334,7 +334,7 @@ void ssKeyerInitialize(long int* start_value_out)
 }
 void ssKeyerValidate(const long int candidate_value_in, long int* validated_value_out)
 {
-  *validated_value_out = LIMIT(candidate_value_in,KeyerMode_e::KEYER_STRAIGHT,KeyerMode_e::KEYER_IAMBIC_B);
+  *validated_value_out = LIMIT(candidate_value_in,(uint8_t)KeyerMode_e::KEYER_STRAIGHT,(uint8_t)KeyerMode_e::KEYER_IAMBIC_B);
 }
 void ssKeyerChange(const long int new_value, char* buff_out, const size_t buff_out_size)
 {
@@ -350,7 +350,7 @@ void ssKeyerChange(const long int new_value, char* buff_out, const size_t buff_o
 }
 void ssKeyerFinalize(const long int final_value)
 {
-  globalSettings.keyerMode = final_value;
+  globalSettings.keyerMode = (KeyerMode_e)final_value;
   SaveSettingsToEeprom();
 }
 const char SS_KEYER_T [] PROGMEM = "CW Keyer/Paddle Type";
@@ -409,7 +409,7 @@ void runResetAllSetting(){runSetting(&ssResetAll);}
 
 struct MenuItem_t {
   const char* const ItemName;
-  const void (*OnSelect)();
+  void (*OnSelect)();
 };
 
 void runMenu(const MenuItem_t* const menu_items, const uint16_t num_items);
@@ -480,7 +480,7 @@ void movePuck(unsigned int old_index, unsigned int new_index)
 void runMenu(const MenuItem_t* const menu_items, const uint16_t num_items)
 {
   static const unsigned int COUNTS_PER_ITEM = 10;
-  const unsigned int MAX_KNOB_VALUE = num_items*COUNTS_PER_ITEM - 1;
+  const int MAX_KNOB_VALUE = num_items*COUNTS_PER_ITEM - 1;
   int knob_sum = 0;
   unsigned int old_index = 0;
 

--- a/ubitx_cat.cpp
+++ b/ubitx_cat.cpp
@@ -19,7 +19,6 @@ static byte rxBufferCheckCount = 0;
 #define CAT_RECEIVE_TIMEOUT 500
 static byte cat[5]; 
 static byte insideCat = 0; 
-static byte useOpenRadioControl = 0;
 
 //for broken protocol
 #define CAT_RECEIVE_TIMEOUT 500

--- a/ubitx_si5351.cpp
+++ b/ubitx_si5351.cpp
@@ -66,12 +66,11 @@ void i2cWriten(uint8_t reg, uint8_t *vals, uint8_t vcnt) {  // write array
 
 
 void si5351bx_init() {                  // Call once at power-up, start PLLA
-  uint8_t reg;  uint32_t msxp1;
   Wire.begin();
   i2cWrite(149, 0);                     // SpreadSpectrum off
   i2cWrite(3, si5351bx_clken);          // Disable all CLK output drivers
   i2cWrite(183, SI5351BX_XTALPF << 6);  // Set 25mhz crystal load capacitance
-  msxp1 = 128 * SI5351BX_MSA - 512;     // and msxp2=0, msxp3=1, not fractional
+  uint32_t msxp1 = 128 * SI5351BX_MSA - 512;     // and msxp2=0, msxp3=1, not fractional
   uint8_t  vals[8] = {0, 1, BB2(msxp1), BB1(msxp1), BB0(msxp1), 0, 0, 0};
   i2cWriten(26, vals, 8);               // Write to 8 PLLA msynth regs
   i2cWrite(177, 0x20);                  // Reset PLLA  (0x80 resets PLLB)

--- a/ubitx_ui.cpp
+++ b/ubitx_ui.cpp
@@ -193,8 +193,9 @@ int getValueByKnob(int minimum, int maximum, int step_size,  int initial, const 
 }
 
 void displayVFO(Vfo_e vfo){
-  int x, y;
-  int displayColor, displayBackground, displayBorder;
+  uint16_t displayColor = COLOR_INACTIVE_TEXT;
+  uint16_t displayBackground = COLOR_INACTIVE_BACKGROUND;
+  uint16_t displayBorder = COLOR_INACTIVE_BORDER;
   Button button;
 
   if (globalSettings.splitOn){

--- a/ubitx_v6.3.1_code.ino
+++ b/ubitx_v6.3.1_code.ino
@@ -305,8 +305,6 @@ void checkPTT(){
 
 //check if the encoder button was pressed
 void checkButton(){
-  int i, t1, t2, knob, new_knob;
-  
   //only if the button is pressed
   if (!btnDown())
     return;
@@ -325,10 +323,9 @@ void checkButton(){
       doSetup2();
       return;
     }
- }
- active_delay(100);
+  }
+  active_delay(100);
 
- 
   doCommands();
   //wait for the button to go up again
   while(btnDown())


### PR DESCRIPTION
This PR is to clean up a bunch of warnings (aka potential errors). There are no functional changes intended.

In C:\Program Files (x86)\Arduino\hardware\arduino\avr\platform.txt, I changed the line to read:
```compiler.warning_flags.all=-Wall -Wextra -Werror```
and removed the `-fpermissive` flag from `compiler.cpp.flags`. This enabled all warnings, disallowed implicit conversions, and refused to compile until all warnings were fixed.

I then fixed the "new" errors until everything compiled again.