### PR TITLE
Band handling updates

### DIFF
--- a/ubitx_ui.cpp
+++ b/ubitx_ui.cpp
@@ -415,16 +415,29 @@ void enterFreq(){
         switch(button.id){
           case KEYS_OK:
           {
-            long freq = atol(c);
-            if((LOWEST_FREQ/1000 <= freq) && (freq <= HIGHEST_FREQ/1000)){
-              freq *= 1000L;
-              setFrequency(freq);
+            long new_freq = atol(c);
+            if((LOWEST_FREQ/1000 <= new_freq) && (new_freq <= HIGHEST_FREQ/1000)){
+              new_freq *= 1000L;
+              
+              long prev_freq = GetActiveVfoFreq();
+              //Transition from below to above the traditional threshold for USB
+              if(prev_freq < THRESHOLD_USB_LSB && new_freq >= THRESHOLD_USB_LSB){
+                SetActiveVfoMode(VfoMode_e::VFO_MODE_USB);
+              }
+              
+              //Transition from aboveo to below the traditional threshold for USB
+              if(prev_freq >= THRESHOLD_USB_LSB && new_freq < THRESHOLD_USB_LSB){
+                SetActiveVfoMode(VfoMode_e::VFO_MODE_LSB);
+              }
+
               if (VFO_A == globalSettings.activeVfo){
-                globalSettings.vfoA.frequency = freq;
+                globalSettings.vfoA.frequency = new_freq;
               }
               else{
-                globalSettings.vfoB.frequency = freq;
+                globalSettings.vfoB.frequency = new_freq;
               }
+
+              setFrequency(new_freq);
               saveVFOs();
             }
             guiUpdate();

--- a/ubitx_ui.cpp
+++ b/ubitx_ui.cpp
@@ -619,10 +619,13 @@ void cwToggle(struct Button *b){
 }
 
 void sidebandToggle(Button* button){
-  if(BUTTON_LSB == button->id)
+  if(BUTTON_LSB == button->id){
     SetActiveVfoMode(VfoMode_e::VFO_MODE_LSB);
-  else
+  }
+  else{
     SetActiveVfoMode(VfoMode_e::VFO_MODE_USB);
+  }
+  setFrequency(GetActiveVfoFreq());
 
   struct Button button2;
   getButton(BUTTON_USB, &button2);

--- a/ubitx_ui.cpp
+++ b/ubitx_ui.cpp
@@ -416,11 +416,11 @@ void enterFreq(){
         switch(button.id){
           case KEYS_OK:
           {
-            long new_freq = atol(c);
+            uint32_t new_freq = atol(c);
             if((LOWEST_FREQ/1000 <= new_freq) && (new_freq <= HIGHEST_FREQ/1000)){
               new_freq *= 1000L;
               
-              long prev_freq = GetActiveVfoFreq();
+              uint32_t prev_freq = GetActiveVfoFreq();
               //Transition from below to above the traditional threshold for USB
               if(prev_freq < THRESHOLD_USB_LSB && new_freq >= THRESHOLD_USB_LSB){
                 SetActiveVfoMode(VfoMode_e::VFO_MODE_USB);


### PR DESCRIPTION
Add auto-sideband-switching to the frequency keypad, and make sideband mode switch via button (USB -> LSB, or LSB->USB) take effect immediately, rather than having to tune to force the change.