### PR TITLE
Remove TX offset in CW mode

### DIFF
--- a/setup.cpp
+++ b/setup.cpp
@@ -147,7 +147,6 @@ void ssLocalOscInitialize(long int* start_value_out){
     uint32_t freq = GetActiveVfoFreq();
     freq = (freq/1000L) * 1000L;//round off the current frequency the nearest kHz
     setFrequency(freq);
-    si5351bx_setfreq(0, globalSettings.usbCarrierFreq); //set back the carrier oscillator, cw tx switches it off
   }
   *start_value_out = globalSettings.oscillatorCal;
 }

--- a/ubitx.h
+++ b/ubitx.h
@@ -95,7 +95,7 @@ static const uint32_t THRESHOLD_USB_LSB = 10000000L;
 /* these are functions implemented in the main file named as ubitx_xxx.ino */
 void active_delay(int delay_by);
 void saveVFOs();
-void setFrequency(unsigned long f);
+void setFrequency(const unsigned long freq, const bool transmit = false);
 void startTx(TuningMode_e tx_mode);
 void stopTx();
 void ritEnable(unsigned long f);

--- a/ubitxv6.ino
+++ b/ubitxv6.ino
@@ -155,29 +155,48 @@ void setTXFilters_v5(unsigned long freq){
  * through mixing of the second local oscillator.
  */
  
-void setFrequency(unsigned long freq){
-  static const unsigned long firstIF = 45005000L;
+void setFrequency(const unsigned long freq,
+                  const bool transmit){
+  static const unsigned long FIRST_IF = 45005000UL;
  
   setTXFilters(freq);
 
-  uint32_t local_osc_freq;
-  if(TuningMode_e::TUNE_CW == globalSettings.tuningMode){
-    local_osc_freq = firstIF + freq + globalSettings.cwSideToneFreq;
-  }
-  else{
-    local_osc_freq = firstIF + freq;
-  }
+  //Nominal values for the oscillators
+  uint32_t local_osc_freq = FIRST_IF + freq;
+  uint32_t ssb_osc_freq = FIRST_IF;//will be changed depending on sideband
+  uint32_t bfo_osc_freq = globalSettings.usbCarrierFreq;
 
-  uint32_t ssb_osc_freq;
-  if(VfoMode_e::VFO_MODE_USB == GetActiveVfoMode()){
-    ssb_osc_freq = firstIF + globalSettings.usbCarrierFreq;
+  if(TuningMode_e::TUNE_CW == globalSettings.tuningMode){
+    if(transmit){
+      //We don't do any mixing or converting when transmitting
+      local_osc_freq = freq;
+      ssb_osc_freq = 0;
+      bfo_osc_freq = 0;
+    }
+    else{
+      //We offset when receiving CW so that it's audible
+      if(VfoMode_e::VFO_MODE_USB == GetActiveVfoMode()){
+        local_osc_freq -= globalSettings.cwSideToneFreq;
+        ssb_osc_freq += globalSettings.usbCarrierFreq;
+      }
+      else{
+        local_osc_freq += globalSettings.cwSideToneFreq;
+        ssb_osc_freq -= globalSettings.usbCarrierFreq;
+      }
+    }
   }
-  else{
-    ssb_osc_freq = firstIF - globalSettings.usbCarrierFreq;
+  else{//SSB mode
+    if(VfoMode_e::VFO_MODE_USB == GetActiveVfoMode()){
+      ssb_osc_freq += globalSettings.usbCarrierFreq;
+    }
+    else{
+      ssb_osc_freq -= globalSettings.usbCarrierFreq;
+    }
   }
 
   si5351bx_setfreq(2, local_osc_freq);
   si5351bx_setfreq(1, ssb_osc_freq);
+  si5351bx_setfreq(0, bfo_osc_freq);
 
   SetActiveVfoFreq(freq);
 }
@@ -196,7 +215,7 @@ void startTx(TuningMode_e tx_mode){
     //save the current as the rx frequency
     uint32_t rit_tx_freq = globalSettings.ritFrequency;
     globalSettings.ritFrequency = GetActiveVfoFreq();
-    setFrequency(rit_tx_freq);
+    setFrequency(rit_tx_freq,true);
   }
   else{
     if(globalSettings.splitOn){
@@ -207,26 +226,9 @@ void startTx(TuningMode_e tx_mode){
         globalSettings.activeVfo = Vfo_e::VFO_B;
       }
     }
-    setFrequency(GetActiveVfoFreq());
+    setFrequency(GetActiveVfoFreq(),true);
   }
 
-  if(TuningMode_e::TUNE_CW == globalSettings.tuningMode){
-    //turn off the second local oscillator and the bfo
-    si5351bx_setfreq(0, 0);
-    si5351bx_setfreq(1, 0);
-
-    //shift the first oscillator to the tx frequency directly
-    //the key up and key down will toggle the carrier unbalancing
-    //the exact cw frequency is the tuned frequency + sidetone
-    if(VfoMode_e::VFO_MODE_USB == GetActiveVfoMode()){
-      si5351bx_setfreq(2, GetActiveVfoFreq() + globalSettings.cwSideToneFreq);
-    }
-    else{
-      si5351bx_setfreq(2, GetActiveVfoFreq() - globalSettings.cwSideToneFreq);
-    }
-
-    delay(20);
-  }
   digitalWrite(TX_RX, 1);//turn on the tx
   globalSettings.txActive = true;
   drawTx();
@@ -235,9 +237,6 @@ void startTx(TuningMode_e tx_mode){
 void stopTx(){
   digitalWrite(TX_RX, 0);//turn off the tx
   globalSettings.txActive = false;
-
-  //set back the carrier oscillator - cw tx switches it off
-  si5351bx_setfreq(0, globalSettings.usbCarrierFreq);
 
   if(globalSettings.ritOn){
     uint32_t rit_rx_freq = globalSettings.ritFrequency;


### PR DESCRIPTION
Currently, when you listen to CW, it (correctly) offsets the CW receive frequency so that the target listen frequency is audible (basically, auto-RIT). However, when you transmit, currently the code also shifts the frequency, so the transmitted carrier is not where the dial says, but offset by the tone Hz value.

W0EB pointed out this issue to me, and it appears that it was discussed at https://groups.io/g/BITX20/topic/20916360, but never fixed in the code.

With this revision, CW transmits on the frequency that's displayed on the screen, and receives above or below that frequency, depending on LSB/USB settings.