### PR TITLE
Arduino IDE 1.8.13 size fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ New features include:
 # Installing on Your Radio
 
 There are plenty of tutorials on how to upload sketches to Arduino Nanos. Just search for them. Addtionally,
-Ashhar created a video explaining the process specifically for uBiTX6: https://www.youtube.com/watch?v=3n_V3prSJ_E
+Ashhar created a video explaining the process specifically for uBiTX v6: https://www.youtube.com/watch?v=3n_V3prSJ_E
 
-I developed this code using the Arduino IDE 1.8.9 toolchain, with -Wall and -Wextra compiler options turned on, so
-it should compile on newer or older versions, but may result in slightly different binary output sizes.
+I developed this code using the Arduino IDE 1.8.9 toolchain, with -Wall and -Wextra compiler options turned on.
+Arduino IDE 1.8.13 was reported to compile too big (see https://groups.io/g/BITX20/topic/75008576), but this
+should be resolved in this project's tag R1.5.1.
 
 # Personalized Callsign
 

--- a/bands.cpp
+++ b/bands.cpp
@@ -16,19 +16,19 @@ struct Band_t {
 const char UNKNOWN_BAND_NAME [] PROGMEM = "??";
 
 constexpr Band_t bands [] PROGMEM {
-  {       0UL,      255UL, 255, "U8"},//Utility conversion option
-  {       0UL,    65535UL, 254, "UF"},//Utility conversion option
-  {  530000UL,  1700000UL, 253, "AM"},//Broadcast AM, actually centers at 268, but uint8 can't do that
-  { 1800000UL,  2000000UL, 160, "A0"},//0xA0 is 160
+//  {       0UL,      255UL, 255, "U8"},//Utility conversion option
+//  {       0UL,    65535UL, 254, "UF"},//Utility conversion option
+//  {  530000UL,  1700000UL, 253, "AM"},//Broadcast AM, actually centers at 268, but uint8 can't do that
+//  { 1800000UL,  2000000UL, 160, "A0"},//0xA0 is 160
   { 3500000UL,  4000000UL,  80, "80"},
-  { 5330500UL,  5403500UL,  60, "60"},
+//  { 5330500UL,  5403500UL,  60, "60"},
   { 7000000UL,  7300000UL,  40, "40"},
   {10100000UL, 10150000UL,  30, "30"},
   {14000000UL, 14350000UL,  20, "20"},
   {18068000UL, 18168000UL,  17, "17"},
   {21000000UL, 21450000UL,  15, "15"},
-  {24890000UL, 24990000UL,  12, "12"},
-  {26965000UL, 27405000UL,  11, "CB"},//Citizen's Band
+//  {24890000UL, 24990000UL,  12, "12"},
+//  {26965000UL, 27405000UL,  11, "CB"},//Citizen's Band
   {28000000UL, 29700000UL,  10, "10"},
 };
 constexpr uint8_t NUM_BANDS = sizeof(bands)/sizeof(bands[0]);


### PR DESCRIPTION
The new Arduino IDE (1.8.13) added bloat that makes the project no longer compile. This PR comments out the bands that are not displayed on the default UI to save some bytes, so that those running on the new IDE can still compile within the nano's bounds.